### PR TITLE
Match Feature Parity With N.EntityFramework.Extensions Part 1

### DIFF
--- a/N.EntityFrameworkCore.Extensions.Test/Data/Product.cs
+++ b/N.EntityFrameworkCore.Extensions.Test/Data/Product.cs
@@ -8,7 +8,7 @@ namespace N.EntityFrameworkCore.Extensions.Test.Data
     public class Product
     {
         [Key]
-        public long Id { get; set; }
+        public string Id { get; set; }
         public decimal Price { get; set; }
         public bool OutOfStock { get; set; }
         public DateTime? UpdatedDateTime { get; set; }

--- a/N.EntityFrameworkCore.Extensions.Test/Data/TphCustomer.cs
+++ b/N.EntityFrameworkCore.Extensions.Test/Data/TphCustomer.cs
@@ -6,5 +6,6 @@ namespace N.EntityFrameworkCore.Extensions.Test.Data
     {
         public string Email { get; set; }
         public string Phone { get; set; }
+        public DateTime AddedDate { get; set; }
     }
 }

--- a/N.EntityFrameworkCore.Extensions.Test/DataContextExtensions/BulkInsert.cs
+++ b/N.EntityFrameworkCore.Extensions.Test/DataContextExtensions/BulkInsert.cs
@@ -1,12 +1,179 @@
-﻿using System;
+﻿using Microsoft.Data.SqlClient;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using N.EntityFrameworkCore.Extensions.Test.Data;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace N.EntityFrameworkCore.Extensions.Test.Tests
+namespace N.EntityFrameworkCore.Extensions.Test.DataContextExtensions
 {
-    class BulkInsert
+    [TestClass]
+    public class BulkInsert : DataContextExtensionsBase
     {
+        [TestMethod]
+        public void With_Default_Options()
+        {
+            var dbContext = SetupDbContext(false);
+            var orders = new List<Order>();
+            for (int i = 0; i < 20000; i++)
+            {
+                orders.Add(new Order { Id = i, Price = 1.57M });
+            }
+            int oldTotal = dbContext.Orders.Where(o => o.Price <= 10).Count();
+            int rowsInserted = dbContext.BulkInsert(orders);
+            int newTotal = dbContext.Orders.Where(o => o.Price <= 10).Count();
+
+            Assert.IsTrue(rowsInserted == orders.Count, "The number of rows inserted must match the count of order list");
+            Assert.IsTrue(newTotal - oldTotal == rowsInserted, "The new count minus the old count should match the number of rows inserted.");
+        }
+        [TestMethod]
+        public void With_Default_Options_Tph()
+        {
+            var dbContext = SetupDbContext(false);
+            var customers = new List<TphCustomer>();
+            var vendors = new List<TphVendor>();
+            for (int i = 0; i < 20000; i++)
+            {
+                customers.Add(new TphCustomer
+                {
+                    Id = i,
+                    FirstName = string.Format("John_{0}", i),
+                    LastName = string.Format("Smith_{0}", i),
+                    Email = string.Format("john.smith{0}@domain.com", i),
+                    Phone = "404-555-1111",
+                    AddedDate = DateTime.UtcNow
+                });
+            }
+            for (int i = 20000; i < 30000; i++)
+            {
+                vendors.Add(new TphVendor
+                {
+                    Id = i,
+                    FirstName = string.Format("Mike_{0}", i),
+                    LastName = string.Format("Smith_{0}", i),
+                    Phone = "404-555-2222",
+                    Email = string.Format("mike.smith{0}@domain.com", i),
+                    Url = string.Format("http://domain.com/mike.smith{0}", i)
+                });
+            }
+            int oldTotal = dbContext.TphPeople.Count();
+            int customerRowsInserted = dbContext.BulkInsert(customers);
+            int vendorRowsInserted = dbContext.BulkInsert(vendors);
+            int rowsInserted = customerRowsInserted + vendorRowsInserted;
+            int newTotal = dbContext.TphPeople.Count();
+
+            Assert.IsTrue(rowsInserted == customers.Count + vendors.Count, "The number of rows inserted must match the count of order list");
+            Assert.IsTrue(newTotal - oldTotal == rowsInserted, "The new count minus the old count should match the number of rows inserted.");
+        }
+        [TestMethod]
+        public void Without_Identity_Column()
+        {
+            var dbContext = SetupDbContext(true);
+            var products = new List<Product>();
+            for (int i = 50000; i < 60000; i++)
+            {
+                products.Add(new Product { Id = i.ToString(), Price = 1.57M });
+            }
+            int oldTotal = dbContext.Products.Where(o => o.Price <= 10).Count();
+            int rowsInserted = dbContext.BulkInsert(products);
+            int newTotal = dbContext.Products.Where(o => o.Price <= 10).Count();
+
+            Assert.IsTrue(rowsInserted == products.Count, "The number of rows inserted must match the count of order list");
+            Assert.IsTrue(newTotal - oldTotal == rowsInserted, "The new count minus the old count should match the number of rows inserted.");
+        }
+        [TestMethod]
+        public void With_Options_AutoMapIdentity()
+        {
+
+            var dbContext = SetupDbContext(false);
+            var orders = new List<Order>();
+            for (int i = 0; i < 5000; i++)
+            {
+                orders.Add(new Order { ExternalId = i.ToString(), Price = ((decimal)i + 0.55M) });
+            }
+            int rowsAdded = dbContext.BulkInsert(orders, new BulkInsertOptions<Order>
+            {
+                UsePermanentTable = true
+            });
+            bool autoMapIdentityMatched = true;
+            var ordersInDb = dbContext.Orders.ToList();
+            Order order1 = null;
+            Order order2 = null;
+            foreach (var order in orders)
+            {
+                order1 = order;
+                var orderinDb = ordersInDb.First(o => o.Id == order.Id);
+                order2 = orderinDb;
+                if (!(orderinDb.ExternalId == order.ExternalId && orderinDb.Price == order.Price))
+                {
+                    autoMapIdentityMatched = false;
+                    break;
+                }
+            }
+
+            Assert.IsTrue(rowsAdded == orders.Count, "The number of rows inserted must match the count of order list");
+            Assert.IsTrue(autoMapIdentityMatched, "The auto mapping of ids of entities that were merged failed to match up");
+        }
+        [TestMethod]
+        public void With_Options_KeepIdentity()
+        {
+            var dbContext = SetupDbContext(false);
+            var orders = new List<Order>();
+            for (int i = 0; i < 20000; i++)
+            {
+                orders.Add(new Order { Id = i, Price = 1.57M });
+            }
+            int oldTotal = dbContext.Orders.Count();
+            int rowsInserted = dbContext.BulkInsert(orders, options => { options.KeepIdentity = true; options.BatchSize = 1000; });
+            var oldOrders = dbContext.Orders.OrderBy(o => o.Id).ToList();
+            var newOrders = dbContext.Orders.OrderBy(o => o.Id).ToList();
+            bool allIdentityFieldsMatch = true;
+            for (int i = 0; i < 20000; i++)
+            {
+                if (newOrders[i].Id != oldOrders[i].Id)
+                {
+                    allIdentityFieldsMatch = false;
+                    break;
+                }
+            }
+            try
+            {
+                int rowsInserted2 = dbContext.BulkInsert(orders, new BulkInsertOptions<Order>()
+                {
+                    KeepIdentity = true,
+                    BatchSize = 1000,
+                });
+            }
+            catch (Exception ex)
+            {
+                Assert.IsInstanceOfType(ex, typeof(SqlException));
+                Assert.IsTrue(ex.Message.StartsWith("Violation of PRIMARY KEY constraint 'PK_Orders'."));
+            }
+
+            Assert.IsTrue(oldTotal == 0, "There should not be any records in the table");
+            Assert.IsTrue(rowsInserted == orders.Count, "The number of rows inserted must match the count of order list");
+            Assert.IsTrue(allIdentityFieldsMatch, "The identities between the source and the database should match.");
+        }
+        [TestMethod]
+        public void With_Options_InsertIfNotExists()
+        {
+            var dbContext = SetupDbContext(true);
+            var orders = new List<Order>();
+            long maxId = dbContext.Orders.Max(o => o.Id);
+            long expectedRowsInserted = 1000;
+            int existingRowsToAdd = 100;
+            long startId = maxId - existingRowsToAdd + 1, endId = maxId + expectedRowsInserted + 1;
+            for (long i = startId; i < endId; i++)
+            {
+                orders.Add(new Order { Id = i, Price = 1.57M });
+            }
+
+            int oldTotal = dbContext.Orders.Where(o => o.Price <= 10).Count();
+            int rowsInserted = dbContext.BulkInsert(orders, new BulkInsertOptions<Order>() { InsertIfNotExists = true });
+            int newTotal = dbContext.Orders.Where(o => o.Price <= 10).Count();
+
+            Assert.IsTrue(rowsInserted == expectedRowsInserted, "The number of rows inserted must match the count of order list");
+            Assert.IsTrue(newTotal - oldTotal == expectedRowsInserted, "The new count minus the old count should match the number of rows inserted.");
+        }
     }
 }

--- a/N.EntityFrameworkCore.Extensions.Test/DataContextExtensions/BulkMerge.cs
+++ b/N.EntityFrameworkCore.Extensions.Test/DataContextExtensions/BulkMerge.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace N.EntityFrameworkCore.Extensions.Test.DataContextExtensions
+{
+    [TestClass]
+    public class BulkMerge : DataContextExtensionsBase
+    {
+    }
+}

--- a/N.EntityFrameworkCore.Extensions.Test/DataContextExtensions/DataContextExtensionsBase.cs
+++ b/N.EntityFrameworkCore.Extensions.Test/DataContextExtensions/DataContextExtensionsBase.cs
@@ -25,8 +25,8 @@ namespace N.EntityFrameworkCore.Extensions.Test.DataContextExtensions
             dbContext.Orders.DeleteFromQuery();
             dbContext.Products.DeleteFromQuery();
             dbContext.Database.ClearTable("TphPeople");
-            ClearTableIfExists(dbContext, "OrdersUnderTen");
-            ClearTableIfExists(dbContext, "OrdersLast30Days");
+            dbContext.Database.DeleteTable("OrdersUnderTen", true);
+            dbContext.Database.DeleteTable("OrdersLast30Days", true);
             if (populateData)
             {
                 var orders = new List<Order>();
@@ -67,24 +67,21 @@ namespace N.EntityFrameworkCore.Extensions.Test.DataContextExtensions
 
                 Debug.WriteLine("Last Id for Order is {0}", id);
                 dbContext.BulkInsert(orders, new BulkInsertOptions<Order>() { KeepIdentity = true });
-                //var order = dbContext.Orders.Where(o => o.Id == 1).FirstOrDefault();
-                //order.Price = 5.22M;
-                //dbContext.SaveChanges();
-                var articles = new List<Product>();
+                var products = new List<Product>();
                 id = 1;
                 for (int i = 0; i < 2050; i++)
                 {
-                    articles.Add(new Product { Id = i, Price = 1.25M, OutOfStock = false });
+                    products.Add(new Product { Id = i.ToString(), Price = 1.25M, OutOfStock = false });
                     id++;
                 }
-                for (int i = 0; i < 2050; i++)
+                for (int i = 2050; i < 7000; i++)
                 {
-                    articles.Add(new Product { Id = i, Price = 1.25M, OutOfStock = true });
+                    products.Add(new Product { Id = i.ToString(), Price = 1.25M, OutOfStock = true });
                     id++;
                 }
 
                 Debug.WriteLine("Last Id for Article is {0}", id);
-                dbContext.BulkInsert(articles, new BulkInsertOptions<Product>() { KeepIdentity = false, AutoMapOutputIdentity = false });
+                dbContext.BulkInsert(products, new BulkInsertOptions<Product>() { KeepIdentity = false, AutoMapOutputIdentity = false });
 
                 //TPH Customers & Vendors
                 var tphCustomers = new List<TphCustomer>();
@@ -116,14 +113,6 @@ namespace N.EntityFrameworkCore.Extensions.Test.DataContextExtensions
                 dbContext.BulkInsert(tphVendors, new BulkInsertOptions<TphVendor>() { KeepIdentity = true });
             }
             return dbContext;
-        }
-
-        private void ClearTableIfExists(DbContext dbContext, string tableName)
-        {
-            if (dbContext.Database.TableExists(tableName))
-            {
-                dbContext.Database.ClearTable(tableName);
-            }
         }
     }
 }

--- a/N.EntityFrameworkCore.Extensions.Test/DataContextExtensions/Fetch.cs
+++ b/N.EntityFrameworkCore.Extensions.Test/DataContextExtensions/Fetch.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace N.EntityFrameworkCore.Extensions.Test.DataContextExtensions
+{
+    [TestClass]
+    public class Fetch : DataContextExtensionsBase
+    {
+        [TestMethod]
+        public void With_DateTime()
+        {
+            var dbContext = SetupDbContext(true);
+            int batchSize = 1000;
+            int batchCount = 0;
+            int totalCount = 0;
+            DateTime dateTime = dbContext.Orders.Max(o => o.AddedDateTime).AddDays(-30);
+            var orders = dbContext.Orders.Where(o => o.AddedDateTime <= dateTime);
+            int expectedTotalCount = orders.Count();
+            int expectedBatchCount = (int)Math.Ceiling(expectedTotalCount / (decimal)batchSize);
+
+            orders.Fetch(result =>
+            {
+                batchCount++;
+                totalCount += result.Results.Count();
+                Assert.IsTrue(result.Results.Count <= batchSize, "The count of results in each batch callback should less than or equal to the batchSize");
+            }, options => { options.BatchSize = batchSize; });
+
+            Assert.IsTrue(expectedTotalCount > 0, "There must be orders in database that match this condition");
+            Assert.IsTrue(expectedTotalCount == totalCount, "The total number of rows fetched must match the count of existing rows in database");
+            Assert.IsTrue(expectedBatchCount == batchCount, "The total number of batches fetched must match what is expected");
+        }
+        [TestMethod]
+        public void With_Decimal()
+        {
+            var dbContext = SetupDbContext(true);
+            int batchSize = 1000;
+            int batchCount = 0;
+            int totalCount = 0;
+            var orders = dbContext.Orders.Where(o => o.Price < 10M);
+            int expectedTotalCount = orders.Count();
+            int expectedBatchCount = (int)Math.Ceiling(expectedTotalCount / (decimal)batchSize);
+
+            orders.Fetch(result =>
+            {
+                batchCount++;
+                totalCount += result.Results.Count();
+                Assert.IsTrue(result.Results.Count <= batchSize, "The count of results in each batch callback should less than or equal to the batchSize");
+            }, options => { options.BatchSize = batchSize; });
+
+            Assert.IsTrue(expectedTotalCount > 0, "There must be orders in database that match this condition");
+            Assert.IsTrue(expectedTotalCount == totalCount, "The total number of rows fetched must match the count of existing rows in database");
+            Assert.IsTrue(expectedBatchCount == batchCount, "The total number of batches fetched must match what is expected");
+        }
+    }
+}

--- a/N.EntityFrameworkCore.Extensions/Common/Constants.cs
+++ b/N.EntityFrameworkCore.Extensions/Common/Constants.cs
@@ -8,6 +8,6 @@ namespace N.EntityFrameworkCore.Extensions.Common
 {
     public static class Constants
     {
-        public readonly static string Guid_ColumnName = "_be_xx_id";
+        public readonly static string InternalId_ColumnName = "_be_xx_id";
     }
 }

--- a/N.EntityFrameworkCore.Extensions/Data/BulkInsertOptions.cs
+++ b/N.EntityFrameworkCore.Extensions/Data/BulkInsertOptions.cs
@@ -10,6 +10,8 @@ namespace N.EntityFrameworkCore.Extensions
         public Expression<Func<T, object>> InputColumns { get; set; }
         public bool AutoMapOutputIdentity { get; set; }
         public bool KeepIdentity { get; set; }
+        public bool InsertIfNotExists { get; set; }
+        public Expression<Func<T, T, bool>> InsertOnCondition { get; set; }
 
         public string[] GetInputColumns()
         {
@@ -19,6 +21,7 @@ namespace N.EntityFrameworkCore.Extensions
         public BulkInsertOptions()
         {
             this.AutoMapOutputIdentity = true;
+            this.InsertIfNotExists = false;
         }
     }
 }

--- a/N.EntityFrameworkCore.Extensions/Data/BulkInsertResult.cs
+++ b/N.EntityFrameworkCore.Extensions/Data/BulkInsertResult.cs
@@ -5,7 +5,7 @@ namespace N.EntityFrameworkCore.Extensions
 {
     internal class BulkInsertResult<T>
     {
-        internal int RowsCopied { get; set; }
-        internal Dictionary<int, T> EntityMap { get; set; }
+        internal int RowsAffected { get; set; }
+        internal Dictionary<long, T> EntityMap { get; set; }
     }
 }

--- a/N.EntityFrameworkCore.Extensions/Data/EntityDataReader.cs
+++ b/N.EntityFrameworkCore.Extensions/Data/EntityDataReader.cs
@@ -12,7 +12,7 @@ namespace N.EntityFrameworkCore.Extensions
     internal class EntityDataReader<T> : IDataReader
     {
         public TableMapping TableMapping { get; set; }
-        public Dictionary<int,T> EntityMap { get; set; }
+        public Dictionary<long,T> EntityMap { get; set; }
         private Dictionary<string, int> columnIndexes;
         private int currentId;
         private bool useInternalId;
@@ -30,7 +30,7 @@ namespace N.EntityFrameworkCore.Extensions
             this.entities = entities;
             this.enumerator = entities.GetEnumerator();
             this.selectors = new Dictionary<int, Func<EntityEntry, object>>();
-            this.EntityMap = new Dictionary<int, T>();
+            this.EntityMap = new Dictionary<long, T>();
             this.FieldCount = tableMapping.Properties.Length;
             this.TableMapping = tableMapping;
             
@@ -57,7 +57,7 @@ namespace N.EntityFrameworkCore.Extensions
             if(useInternalId)
             {
                 this.FieldCount++;
-                columnIndexes[Constants.Guid_ColumnName] = i;
+                columnIndexes[Constants.InternalId_ColumnName] = i;
             }
         }
 

--- a/N.EntityFrameworkCore.Extensions/N.EntityFrameworkCore.Extensions.csproj
+++ b/N.EntityFrameworkCore.Extensions/N.EntityFrameworkCore.Extensions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.5.5</Version>
+    <Version>1.5.6</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/NorthernLight1/N.EntityFrameworkCore.Extensions/</PackageProjectUrl>
     <Authors>Northern25</Authors>


### PR DESCRIPTION
Renamed Constants.Guid_ColumnName to Constants.InternalId_ColumnName
Updated Product.Id to use string instead of int for testing purposes
Added AddedDate to TphCustomer.cs for test cases
Added various bug fixes to BulkInsert function
Added InsertIfNotExists flag to BulkInsertOptions so that records can be bulk inserted into a table, only if they don't exist otherwise they are ignored.
Updated Nuget version to 1.5.6