### PR TITLE
Rewrite ToSqlPredicate to handle enums and skip using reflection

### DIFF
--- a/.idea/.idea.N.EntityFrameworkCore.Extensions/.idea/.gitignore
+++ b/.idea/.idea.N.EntityFrameworkCore.Extensions/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/.idea.N.EntityFrameworkCore.Extensions.iml
+/contentModel.xml
+/modules.xml
+/projectSettingsUpdater.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/N.EntityFrameworkCore.Extensions.Test/Data/Order.cs
+++ b/N.EntityFrameworkCore.Extensions.Test/Data/Order.cs
@@ -17,10 +17,18 @@ namespace N.EntityFrameworkCore.Extensions.Test.Data
         public DateTime DbModifiedDateTime { get; set; }
         public bool? Trigger { get; set; }
         public bool Active { get; set; }
+        public OrderStatus Status { get; set; }
         public Order()
         {
             AddedDateTime = DateTime.UtcNow;
             Active = true;
         }
+    }
+
+    public enum OrderStatus
+    {
+        Unknown,
+        Completed,
+        Error   
     }
 }

--- a/N.EntityFrameworkCore.Extensions.Test/Data/TestDbContext.cs
+++ b/N.EntityFrameworkCore.Extensions.Test/Data/TestDbContext.cs
@@ -36,6 +36,7 @@ namespace N.EntityFrameworkCore.Extensions.Test.Data
             modelBuilder.Entity<ProductWithComplexKey>().Property<Guid>("Key3").HasDefaultValueSql("newsequentialid()");
             modelBuilder.Entity<Order>().Property<DateTime>("DbAddedDateTime").HasDefaultValueSql("getdate()");
             modelBuilder.Entity<Order>().Property<DateTime>("DbModifiedDateTime").HasComputedColumnSql("getdate()");
+            modelBuilder.Entity<Order>().Property(p => p.Status).HasConversion<string>();
             modelBuilder.Entity<TpcPerson>().UseTpcMappingStrategy();
             modelBuilder.Entity<TpcCustomer>().ToTable("TpcCustomer");
             modelBuilder.Entity<TpcVendor>().ToTable("TpcVendor");

--- a/N.EntityFrameworkCore.Extensions.Test/DbContextExtensions/BulkInsert.cs
+++ b/N.EntityFrameworkCore.Extensions.Test/DbContextExtensions/BulkInsert.cs
@@ -228,10 +228,11 @@ namespace N.EntityFrameworkCore.Extensions.Test.DbContextExtensions
             var orders = new List<Order>();
             for (int i = 0; i < 20000; i++)
             {
-                orders.Add(new Order { Id = i, ExternalId = i.ToString(), Price = 1.57M, Active = true });
+                orders.Add(new Order { Id = i, ExternalId = i.ToString(), Price = 1.57M, Active = true, Status = OrderStatus.Completed});
             }
             int oldTotal = dbContext.Orders.Where(o => o.Price == 1.57M && o.ExternalId == null && o.Active == true).Count();
-            int rowsInserted = dbContext.BulkInsert(orders, options => { options.UsePermanentTable = true; options.InputColumns = o => new { o.Price, o.Active, o.AddedDateTime }; });
+            int rowsInserted = dbContext.BulkInsert(orders, options => { options.UsePermanentTable = true; 
+                options.InputColumns = o => new { o.Price, o.Active, o.AddedDateTime, o.Status }; });
             int newTotal = dbContext.Orders.Where(o => o.Price == 1.57M && o.ExternalId == null && o.Active == true).Count();
 
             Assert.IsTrue(rowsInserted == orders.Count, "The number of rows inserted must match the count of order list");

--- a/N.EntityFrameworkCore.Extensions.Test/DbContextExtensions/BulkInsertAsync.cs
+++ b/N.EntityFrameworkCore.Extensions.Test/DbContextExtensions/BulkInsertAsync.cs
@@ -247,10 +247,11 @@ namespace N.EntityFrameworkCore.Extensions.Test.DbContextExtensions
             var orders = new List<Order>();
             for (int i = 0; i < 20000; i++)
             {
-                orders.Add(new Order { Id = i, ExternalId = i.ToString(), Price = 1.57M, Active = true });
+                orders.Add(new Order { Id = i, ExternalId = i.ToString(), Price = 1.57M, Active = true, Status = OrderStatus.Completed});
             }
             int oldTotal = dbContext.Orders.Where(o => o.Price == 1.57M && o.ExternalId == null && o.Active == true).Count();
-            int rowsInserted = await dbContext.BulkInsertAsync(orders, options => { options.UsePermanentTable = true; options.InputColumns = o => new { o.Price, o.Active, o.AddedDateTime }; });
+            int rowsInserted = await dbContext.BulkInsertAsync(orders, options => { options.UsePermanentTable = true; 
+                options.InputColumns = o => new { o.Price, o.Active, o.AddedDateTime, o.Status }; });
             int newTotal = dbContext.Orders.Where(o => o.Price == 1.57M && o.ExternalId == null && o.Active == true).Count();
 
             Assert.IsTrue(rowsInserted == orders.Count, "The number of rows inserted must match the count of order list");

--- a/N.EntityFrameworkCore.Extensions.Test/DbContextExtensions/BulkMergeAsync.cs
+++ b/N.EntityFrameworkCore.Extensions.Test/DbContextExtensions/BulkMergeAsync.cs
@@ -325,5 +325,22 @@ namespace N.EntityFrameworkCore.Extensions.Test.DbContextExtensions
             Assert.IsTrue(result.RowsInserted == orders.Count(), "The number of rows inserted must match the count of order list");
             Assert.IsTrue(newTotal - oldTotal == result.RowsInserted, "The new count minus the old count should match the number of rows inserted.");
         }
+        [TestMethod]
+        public async Task With_Merge_On_Enum()
+        {
+            var dbContext = SetupDbContext(true);
+            await dbContext.BulkSaveChangesAsync();
+            var nowDateTime = DateTime.Now;
+            var orders = new List<Order>();
+            for (int i = 0; i < 20; i++)
+            {
+                orders.Add(new Order { Id = i, Price = 1.57M, DbModifiedDateTime = nowDateTime, Status = OrderStatus.Completed});
+            }
+
+            var result = await dbContext.BulkMergeAsync(orders, options => options.MergeOnCondition = (s, t) => s.Id == t.Id && s.Status == t.Status);
+
+            Assert.AreEqual(1, result.RowsInserted);
+            Assert.AreEqual(19, result.RowsUpdated);
+        }
     }
 }

--- a/N.EntityFrameworkCore.Extensions.Test/DbContextExtensions/DbContextExtensionsBase.cs
+++ b/N.EntityFrameworkCore.Extensions.Test/DbContextExtensions/DbContextExtensionsBase.cs
@@ -56,7 +56,8 @@ namespace N.EntityFrameworkCore.Extensions.Test.DbContextExtensions
                             ExternalId = string.Format("id-{0}", i),
                             Price = 1.25M,
                             AddedDateTime = addedDateTime,
-                            ModifiedDateTime = addedDateTime.AddHours(3)
+                            ModifiedDateTime = addedDateTime.AddHours(3),
+                            Status = OrderStatus.Completed
                         });
                         id++;
                     }

--- a/N.EntityFrameworkCore.Extensions.Test/LinqExtensions/ToSqlPredicateTests.cs
+++ b/N.EntityFrameworkCore.Extensions.Test/LinqExtensions/ToSqlPredicateTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Linq.Expressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace N.EntityFrameworkCore.Extensions.Test.LinqExtensions;
+
+[TestClass]
+public class ToSqlPredicateTests
+{
+    [TestMethod]
+    public void Should_handle_int()
+    {
+        Expression<Func<Entity, Entity, bool>> expression = (s, t) => s.Id == t.Id;
+
+        var sqlPredicate = expression.ToSqlPredicate("s", "t");
+
+        Assert.AreEqual("s.Id = t.Id",sqlPredicate);
+    }
+    
+    [TestMethod]
+    public void Should_handle_enum()
+    {
+        Expression<Func<Entity, Entity, bool>> expression = (s, t) => s.Type == t.Type;
+
+        var sqlPredicate = expression.ToSqlPredicate("s", "t");
+
+        Assert.AreEqual("s.Type = t.Type",sqlPredicate);
+    }
+
+    [TestMethod]
+    public void Should_handle_complex_one()
+    {
+        Expression<Func<Entity, Entity, bool>> expression = (s, t) => s.Type == t.Type &&
+                                                                      (s.Id == t.Id &&
+                                                                       s.ExternalId == t.ExternalId);
+
+        var sqlPredicate = expression.ToSqlPredicate("s", "t");
+
+        Assert.AreEqual("s.Type = t.Type AND s.Id = t.Id AND s.ExternalId = t.ExternalId", sqlPredicate);
+    }
+
+    [TestMethod]
+    public void Should_handle_prop_naming()
+    {
+        Expression<Func<Entity, Entity, bool>> expression = (source, target) => source.Id == target.Id &&
+                                                                                source.ExternalId == target.ExternalId;
+
+        var sqlPredicate = expression.ToSqlPredicate("s", "t");
+
+        Assert.AreEqual("s.Id = t.Id AND s.ExternalId = t.ExternalId", sqlPredicate);
+    }
+    
+    record Entity
+    {
+        public Guid Id { get; set; }
+        public EntityType Type { get; set; }
+        public int ExternalId { get; set; }
+    }
+
+    enum EntityType
+    {
+        One,
+        Two,
+        Three
+    }
+}

--- a/N.EntityFrameworkCore.Extensions/Extensions/LinqExtensions.cs
+++ b/N.EntityFrameworkCore.Extensions/Extensions/LinqExtensions.cs
@@ -130,20 +130,45 @@ namespace N.EntityFrameworkCore.Extensions
                 throw new InvalidOperationException("GetObjectProperties() encountered an unsupported expression type");
             }
         }
+        
         internal static string ToSqlPredicate<T>(this Expression<T> expression, params string[] parameters)
         {
-            var stringBuilder = new StringBuilder((string)expression.Body.GetPrivateFieldValue("DebugView"));
-            int i = 0;
-            foreach (var expressionParam in expression.Parameters)
-            {
-                if (parameters.Length <= i) break;
-                stringBuilder.Replace((string)expressionParam.GetPrivateFieldValue("DebugView"), parameters[i]);
-                i++;
-            }
-            stringBuilder.Replace("&&", "AND");
-            stringBuilder.Replace("==", "=");
-            return stringBuilder.ToString();
+            var sql = ToSqlString(expression.Body);
+
+            for (var i = 0; i < parameters.Length; i++)
+                sql = sql.Replace($"${expression.Parameters[i].Name!}.", $"{parameters[i]}.");
+
+            return sql;
         }
+       
+        static string ToSqlString(Expression expression, string sql = null)
+        {
+            sql ??= "";
+            if (expression is not BinaryExpression b)
+                return sql;
+
+            var internalSql = "";
+            if (b.Left is MemberExpression mel)
+                internalSql += $"${mel} = ";
+            if (b.Right is MemberExpression mer)
+                internalSql += $"${mer}";
+
+            if (b.Left is UnaryExpression ubl)
+                internalSql += $"${ubl.Operand} = ";
+            if (b.Right is UnaryExpression ubr)
+                internalSql += $"${ubr.Operand}";
+
+            if (!string.IsNullOrWhiteSpace(internalSql))
+                return internalSql;
+
+            var left = ToSqlString(b.Left, sql);
+            if (string.IsNullOrWhiteSpace(left))
+                return sql;
+
+            var right = ToSqlString(b.Right, sql);
+            return left + " AND " + right;
+        }
+        
         internal static string ToSqlUpdateSetExpression<T>(this Expression<T> expression, string tableName)
         {
             List<string> setValues = new List<string>();

--- a/N.EntityFrameworkCore.Extensions/Extensions/LinqExtensions.cs
+++ b/N.EntityFrameworkCore.Extensions/Extensions/LinqExtensions.cs
@@ -134,7 +134,7 @@ namespace N.EntityFrameworkCore.Extensions
                 throw new InvalidOperationException("GetObjectProperties() encountered an unsupported expression type");
             }
         }
-        internal static string ToSqlPredicate2<T>(this Expression<T> expression, params string[] parameters)
+        internal static string ToSqlPredicate<T>(this Expression<T> expression, params string[] parameters)
         {
             var sql = ToSqlString(expression.Body);
 
@@ -195,21 +195,6 @@ namespace N.EntityFrameworkCore.Extensions
                 return $"{unaryExpression.Operand}";
             }
             return sb.ToString();
-        }
-        internal static string ToSqlPredicate<T>(this Expression<T> expression, params string[] parameters)
-        {
-            var stringBuilder = new StringBuilder((string)expression.Body.GetPrivateFieldValue("DebugView"));
-            int i = 0;
-            foreach (var expressionParam in expression.Parameters)
-            {
-                if (parameters.Length <= i) break;
-                stringBuilder.Replace((string)expressionParam.GetPrivateFieldValue("DebugView"), parameters[i]);
-                i++;
-            }
-            stringBuilder.Replace("&&", "AND");
-            stringBuilder.Replace("==", "=");
-            stringBuilder.Replace("(System.Nullable`1[System.Int32])", "");
-            return stringBuilder.ToString();
         }
         internal static string ToSqlUpdateSetExpression<T>(this Expression<T> expression, string tableName)
         {

--- a/N.EntityFrameworkCore.Extensions/Extensions/LinqExtensions.cs
+++ b/N.EntityFrameworkCore.Extensions/Extensions/LinqExtensions.cs
@@ -134,7 +134,7 @@ namespace N.EntityFrameworkCore.Extensions
                 throw new InvalidOperationException("GetObjectProperties() encountered an unsupported expression type");
             }
         }
-        internal static string ToSqlPredicate<T>(this Expression<T> expression, params string[] parameters)
+        internal static string ToSqlPredicate2<T>(this Expression<T> expression, params string[] parameters)
         {
             var sql = ToSqlString(expression.Body);
 

--- a/N.EntityFrameworkCore.Extensions/Extensions/LinqExtensions.cs
+++ b/N.EntityFrameworkCore.Extensions/Extensions/LinqExtensions.cs
@@ -134,7 +134,7 @@ namespace N.EntityFrameworkCore.Extensions
                 throw new InvalidOperationException("GetObjectProperties() encountered an unsupported expression type");
             }
         }
-        internal static string ToSqlPredicate<T>(this Expression<T> expression, params string[] parameters)
+        internal static string ToSqlPredicate2<T>(this Expression<T> expression, params string[] parameters)
         {
             var sql = ToSqlString(expression.Body);
 
@@ -195,6 +195,21 @@ namespace N.EntityFrameworkCore.Extensions
                 return $"{unaryExpression.Operand}";
             }
             return sb.ToString();
+        }
+        internal static string ToSqlPredicate<T>(this Expression<T> expression, params string[] parameters)
+        {
+            var stringBuilder = new StringBuilder((string)expression.Body.GetPrivateFieldValue("DebugView"));
+            int i = 0;
+            foreach (var expressionParam in expression.Parameters)
+            {
+                if (parameters.Length <= i) break;
+                stringBuilder.Replace((string)expressionParam.GetPrivateFieldValue("DebugView"), parameters[i]);
+                i++;
+            }
+            stringBuilder.Replace("&&", "AND");
+            stringBuilder.Replace("==", "=");
+            stringBuilder.Replace("(System.Nullable`1[System.Int32])", "");
+            return stringBuilder.ToString();
         }
         internal static string ToSqlUpdateSetExpression<T>(this Expression<T> expression, string tableName)
         {

--- a/N.EntityFrameworkCore.Extensions/Extensions/LinqExtensions.cs
+++ b/N.EntityFrameworkCore.Extensions/Extensions/LinqExtensions.cs
@@ -209,6 +209,7 @@ namespace N.EntityFrameworkCore.Extensions
             stringBuilder.Replace("&&", "AND");
             stringBuilder.Replace("==", "=");
             stringBuilder.Replace("(System.Nullable`1[System.Int32])", "");
+            stringBuilder.Replace("(System.Int32)", "");
             return stringBuilder.ToString();
         }
         internal static string ToSqlUpdateSetExpression<T>(this Expression<T> expression, string tableName)

--- a/N.EntityFrameworkCore.Extensions/N.EntityFrameworkCore.Extensions.csproj
+++ b/N.EntityFrameworkCore.Extensions/N.EntityFrameworkCore.Extensions.csproj
@@ -32,4 +32,8 @@ Inheritance models supported: Table-Per-Concrete, Table-Per-Hierarchy, Table-Per
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="N.EntityFrameworkCore.Extensions.Test" />
+  </ItemGroup>
+  
 </Project>


### PR DESCRIPTION
Rewrite `ToSqlPredicate` to handle Enums. Currently SQL with enums get converted to `(System.Int32)s.Type = (System.Int32)t.Type`.

The new suggested solution also skips the using of reflection.