### PR TITLE
Enable enum parsning for bulk fetch, fetch and fetch async

### DIFF
--- a/N.EntityFrameworkCore.Extensions.Test/DbContextExtensions/BulkFetch.cs
+++ b/N.EntityFrameworkCore.Extensions.Test/DbContextExtensions/BulkFetch.cs
@@ -33,6 +33,28 @@ namespace N.EntityFrameworkCore.Extensions.Test.DbContextExtensions
             Assert.IsTrue(ordersAreMatched, "The orders from BulkFetch() should match what is retrieved from DbContext");
         }
         [TestMethod]
+        public void With_Enum()
+        {
+            var dbContext = SetupDbContext(true);
+            var products = dbContext.Products.Where(o => o.Price == 1.25m).ToList();
+            var fetchedProducts = dbContext.Products.BulkFetch(products);
+            bool ordersAreMatched = true;
+
+            foreach (var fetchedOrder in fetchedProducts)
+            {
+                var order = products.First(o => o.Id == fetchedOrder.Id);
+                if (order.Id != fetchedOrder.Id || order.Name != fetchedOrder.Name || order.StatusEnum != fetchedOrder.StatusEnum)
+                {
+                    ordersAreMatched = false;
+                    break;
+                }
+            }
+
+            Assert.IsTrue(products.Count > 0, "There must be orders in database that match this condition (Price = $1.25)");
+            Assert.IsTrue(products.Count == fetchedProducts.Count(), "The number of rows deleted must match the count of existing rows in database");
+            Assert.IsTrue(ordersAreMatched, "The orders from BulkFetch() should match what is retrieved from DbContext");
+        }
+        [TestMethod]
         public void With_IQueryable()
         {
             var dbContext = SetupDbContext(true);

--- a/N.EntityFrameworkCore.Extensions.Test/DbContextExtensions/Fetch.cs
+++ b/N.EntityFrameworkCore.Extensions.Test/DbContextExtensions/Fetch.cs
@@ -105,6 +105,28 @@ namespace N.EntityFrameworkCore.Extensions.Test.DbContextExtensions
             Assert.IsTrue(expectedBatchCount == batchCount, "The total number of batches fetched must match what is expected");
         }
         [TestMethod]
+        public void With_Enum()
+        {
+            var dbContext = SetupDbContext(true);
+            int batchSize = 1000;
+            int batchCount = 0;
+            int totalCount = 0;
+            var products = dbContext.Products.Where(o => o.Price < 10M);
+            int expectedTotalCount = products.Count();
+            int expectedBatchCount = (int)Math.Ceiling(expectedTotalCount / (decimal)batchSize);
+
+            products.Fetch(result =>
+            {
+                batchCount++;
+                totalCount += result.Results.Count();
+                Assert.IsTrue(result.Results.Count <= batchSize, "The count of results in each batch callback should less than or equal to the batchSize");
+            }, options => { options.BatchSize = batchSize; });
+
+            Assert.IsTrue(expectedTotalCount > 0, "There must be products in database that match this condition");
+            Assert.IsTrue(expectedTotalCount == totalCount, "The total number of rows fetched must match the count of existing rows in database");
+            Assert.IsTrue(expectedBatchCount == batchCount, "The total number of batches fetched must match what is expected");
+        }
+        [TestMethod]
         public void With_Options_IgnoreColumns()
         {
             var dbContext = SetupDbContext(true);
@@ -128,7 +150,7 @@ namespace N.EntityFrameworkCore.Extensions.Test.DbContextExtensions
             Assert.IsTrue(expectedTotalCount == totalCount, "The total number of rows fetched must match the count of existing rows in database");
             Assert.IsTrue(expectedBatchCount == batchCount, "The total number of batches fetched must match what is expected");
         }
-    [TestMethod]
+        [TestMethod]
         public void With_Options_InputColumns()
         {
             var dbContext = SetupDbContext(true);

--- a/N.EntityFrameworkCore.Extensions.Test/DbContextExtensions/FetchAsync.cs
+++ b/N.EntityFrameworkCore.Extensions.Test/DbContextExtensions/FetchAsync.cs
@@ -8,7 +8,7 @@ namespace N.EntityFrameworkCore.Extensions.Test.DbContextExtensions
     [TestClass]
     public class FetchAsync : DbContextExtensionsBase
     {
-                [TestMethod]
+        [TestMethod]
         public async Task With_BulkInsert()
         {
             var dbContext = SetupDbContext(true);
@@ -107,6 +107,31 @@ namespace N.EntityFrameworkCore.Extensions.Test.DbContextExtensions
             }, options => { options.BatchSize = batchSize; });
 
             Assert.IsTrue(expectedTotalCount > 0, "There must be orders in database that match this condition");
+            Assert.IsTrue(expectedTotalCount == totalCount, "The total number of rows fetched must match the count of existing rows in database");
+            Assert.IsTrue(expectedBatchCount == batchCount, "The total number of batches fetched must match what is expected");
+        }
+        [TestMethod]
+        public async Task With_Enum()
+        {
+            var dbContext = SetupDbContext(true);
+            int batchSize = 1000;
+            int batchCount = 0;
+            int totalCount = 0;
+            var products = dbContext.Products.Where(o => o.Price < 10M);
+            int expectedTotalCount = products.Count();
+            int expectedBatchCount = (int)Math.Ceiling(expectedTotalCount / (decimal)batchSize);
+
+            await products.FetchAsync(async result =>
+            {
+                await Task.Run(() =>
+                {
+                    batchCount++;
+                    totalCount += result.Results.Count();
+                    Assert.IsTrue(result.Results.Count <= batchSize, "The count of results in each batch callback should less than or equal to the batchSize");
+                });
+            }, options => { options.BatchSize = batchSize; });
+
+            Assert.IsTrue(expectedTotalCount > 0, "There must be products in database that match this condition");
             Assert.IsTrue(expectedTotalCount == totalCount, "The total number of rows fetched must match the count of existing rows in database");
             Assert.IsTrue(expectedBatchCount == batchCount, "The total number of batches fetched must match what is expected");
         }

--- a/N.EntityFrameworkCore.Extensions/Extensions/DbDataReaderExtensions.cs
+++ b/N.EntityFrameworkCore.Extensions/Extensions/DbDataReaderExtensions.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Reflection;
+
+namespace N.EntityFrameworkCore.Extensions.Extensions;
+
+static class DbDataReaderExtensions
+{
+    internal static T MapEntity<T>(this DbDataReader reader, List<PropertyInfo> propertySetters) where T : class, new()
+    {
+        var entity = new T();
+        for (var i = 0; i < reader.FieldCount; i++)
+        {
+            var value = reader.GetValue(i);
+            if (value == DBNull.Value)
+                value = null;
+
+            var prop = propertySetters[i];
+            if (prop == null) continue;
+
+            if (prop.PropertyType.IsEnum)
+            {
+                var valueString = value?.ToString();
+                prop.SetValue(entity, string.IsNullOrWhiteSpace(valueString) ? null : Enum.Parse(prop.PropertyType, valueString));
+            }
+            else if (prop.PropertyType.IsNullableEnum())
+            {
+                var valueString = value?.ToString();
+                var enumType = Nullable.GetUnderlyingType(prop.PropertyType)!;
+                prop.SetValue(entity, string.IsNullOrWhiteSpace(valueString) ? null : Enum.Parse(enumType, valueString));
+            }
+            else
+            {
+                prop.SetValue(entity, value);
+            }
+        }
+
+        return entity;
+    }
+
+    static bool IsNullableEnum(this Type t)
+    {
+        var u = Nullable.GetUnderlyingType(t);
+        return u is { IsEnum: true };
+    }
+
+    internal static List<PropertyInfo> GetPropertyInfos<T>(this DbDataReader reader)
+    {
+        var propertySetters = new List<PropertyInfo>();
+        var entityType = typeof(T);
+
+        for (var i = 0; i < reader.FieldCount; i++)
+        {
+            var prop = entityType.GetProperty(reader.GetName(i));
+            propertySetters.Add(prop);
+        }
+
+        return propertySetters;
+    }
+}


### PR DESCRIPTION
- Enable enum parsning for bulk fetch, fetch and fetch async. 
- Minor refactoring to be able to reuse the mapping logic to from DbDataReader to entity.